### PR TITLE
fix: prevent garbled text by setting `Accept-Encoding: identity` header

### DIFF
--- a/internal/common/api_check.go
+++ b/internal/common/api_check.go
@@ -57,6 +57,7 @@ func TestChatAPI(apiKey string) (bool, string, error) {
 	// 设置请求头
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	req.Header.Set("Accept-Encoding", "identity")
 
 	// 创建HTTP客户端
 	client := utils.CreateClient()
@@ -139,6 +140,7 @@ func TestImageGeneration(apiKey string) (bool, string, error) {
 	// 设置请求头
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	req.Header.Set("Accept-Encoding", "identity")
 
 	logger.Info("图片生成测试使用的API密钥: %s", utils.MaskKey(apiKey))
 
@@ -230,6 +232,7 @@ func TestModelsAPI(apiKey string) (bool, string, error) {
 	// 设置请求头
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	req.Header.Set("Accept-Encoding", "identity")
 
 	logger.Info("模型列表测试使用的API密钥: %s", utils.MaskKey(apiKey))
 
@@ -332,6 +335,7 @@ func TestRerankAPI(apiKey string) (bool, string, error) {
 	// 设置请求头
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	req.Header.Set("Accept-Encoding", "identity")
 
 	logger.Info("重排序测试使用的API密钥: %s", utils.MaskKey(apiKey))
 
@@ -424,6 +428,7 @@ func TestEmbeddings(apiKey string) (bool, string, error) {
 	// 设置请求头
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	req.Header.Set("Accept-Encoding", "identity")
 
 	// 创建HTTP客户端
 	client := utils.CreateClient()

--- a/internal/model/model_db.go
+++ b/internal/model/model_db.go
@@ -200,6 +200,7 @@ func fetchRemoteModels(baseURL string) ([]string, int, error) {
 	apikeys := config.GetActiveApiKeys()
 	req.Header.Set("Authorization", "Bearer "+apikeys[0].Key)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "identity")
 
 	// 发送请求
 	client := &http.Client{}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -158,6 +158,9 @@ func handleApiProxyWithRetry(c *gin.Context, targetURL string, bodyBytes []byte,
 		// 设置 Authorization header
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
 
+		// 明确指定不接受压缩响应，避免 Cloudflare 返回 br 压缩格式
+		req.Header.Set("Accept-Encoding", "identity")
+
 		// 创建 HTTP 客户端
 		client := utils.CreateClient()
 
@@ -269,6 +272,9 @@ func processApiRequest(c *gin.Context, targetURL string, bodyBytes []byte, reque
 
 	// 设置 Authorization header
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+
+	// 明确指定不接受压缩响应，避免 Cloudflare 返回 br 压缩格式
+	req.Header.Set("Accept-Encoding", "identity")
 
 	// 创建 HTTP 客户端
 	client := utils.CreateClient()
@@ -733,6 +739,9 @@ func handleOpenAIProxyWithRetry(c *gin.Context, targetURL string, transformedBod
 		// 设置 Content-Type header
 		req.Header.Set("Content-Type", "application/json")
 
+		// 明确指定不接受压缩响应，避免 Cloudflare 返回 br 压缩格式
+		req.Header.Set("Accept-Encoding", "identity")
+
 		// 创建 HTTP 客户端
 		client := utils.CreateClient()
 
@@ -936,6 +945,9 @@ func handleOpenAIStreamRequest(c *gin.Context, targetURL string, transformedBody
 		req.Header.Set("X-DeepSeek-Priority", "high") // 自定义头，可能会被忽略，但不影响
 	}
 
+	// 明确指定不接受压缩响应，避免 Cloudflare 返回 br 压缩格式
+	req.Header.Set("Accept-Encoding", "identity")
+
 	// 创建 HTTP 客户端，根据模型类型选择合适的超时设置
 	var client *http.Client
 	if isDeepseekR1 {
@@ -1109,6 +1121,9 @@ func processOpenAIRequest(c *gin.Context, targetURL string, transformedBody []by
 	// 设置 Content-Type header
 	req.Header.Set("Content-Type", "application/json")
 
+	// 明确指定不接受压缩响应，避免 Cloudflare 返回 br 压缩格式
+	req.Header.Set("Accept-Encoding", "identity")
+
 	// 创建 HTTP 客户端
 	client := utils.CreateClient()
 
@@ -1219,6 +1234,9 @@ func HandleModelsRequest(c *gin.Context, apiKey string) {
 	// 设置请求头
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	// 明确指定不接受压缩响应，避免 Cloudflare 返回 br 压缩格式
+	req.Header.Set("Accept-Encoding", "identity")
+
 	// 创建HTTP客户端
 	client := utils.CreateClient()
 
@@ -1958,6 +1976,9 @@ func forwardUserInfoRequest(c *gin.Context, targetURL string) {
 
 	// 设置 Content-Type header
 	req.Header.Set("Content-Type", "application/json")
+
+	// 明确指定不接受压缩响应，避免 Cloudflare 返回 br 压缩格式
+	req.Header.Set("Accept-Encoding", "identity")
 
 	// 创建 HTTP 客户端
 	client := utils.CreateClient()

--- a/web/handle.go
+++ b/web/handle.go
@@ -1275,6 +1275,7 @@ func handleApiKeyProxy(c *gin.Context) {
 	// 添加授权头
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "identity") // 明确指定不接受压缩响应
 
 	// 创建HTTP客户端并发送请求
 	client := &http.Client{
@@ -1431,6 +1432,7 @@ func fetchRemoteModels(baseURL string) ([]string, int, error) {
 	apikeys := config.GetActiveApiKeys()
 	req.Header.Set("Authorization", "Bearer "+apikeys[0].Key)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "identity") // 明确指定不接受压缩响应
 
 	// 发送请求
 	client := &http.Client{}


### PR DESCRIPTION
Issue: #2 

SiliconFlow 提供了一个海外端点 api-st.siliconflow.cn，使用 Cloudflare 转发请求。Cloudflare 默认会用 Brotli 压缩响应数据，而代码里没有做解码，导致出现乱码。

在所有 HTTP 请求中添加了 `Accept-Encoding: identity` 请求头，这样 Cloudflare 返回数据的时候就不会做压缩，我们也不用额外引入库来做解码。